### PR TITLE
bump version from 1.0.6 to 1.0.7

### DIFF
--- a/LookinServer.podspec
+++ b/LookinServer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "LookinServer"
-  spec.version      = "1.0.6"
+  spec.version      = "1.0.7"
   spec.summary      = "The iOS framework of Lookin."
   spec.description  = "Embed this framework into your iOS project to enable Lookin mac app."
   spec.homepage     = "https://lookin.work"
@@ -8,8 +8,8 @@ Pod::Spec.new do |spec|
   spec.author       = { "Li Kai" => "lookin@lookin.work" }
   spec.ios.deployment_target  = "9.0"
   spec.tvos.deployment_target  = '9.0'
-  
-  spec.source       = { :git => "https://github.com/QMUI/LookinServer.git", :tag => "1.0.6"}
+
+  spec.source       = { :git => "https://github.com/QMUI/LookinServer.git", :tag => "1.0.7"}
   spec.framework  = "UIKit"
   spec.requires_arc = true
   spec.source_files = 'Src/**/*'

--- a/LookinShared.podspec
+++ b/LookinShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "LookinShared"
-  spec.version      = "1.0.6"
+  spec.version      = "1.0.7"
   spec.summary      = "The shared files between client and server side of Lookin."
   spec.description  = "Embed this framework into your iOS project to enable Lookin mac app."
   spec.homepage     = "https://lookin.work"
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
   spec.tvos.deployment_target  = '9.0'
   spec.macos.deployment_target = "10.14"
 
-  spec.source       = { :git => "https://github.com/QMUI/LookinServer.git", :tag => "1.0.6"}
+  spec.source       = { :git => "https://github.com/QMUI/LookinServer.git", :tag => "1.0.7"}
   #spec.framework  = "UIKit"
   spec.requires_arc = true
   spec.source_files = 'Src/Shared/**/*'

--- a/Src/Shared/LookinDefines.h
+++ b/Src/Shared/LookinDefines.h
@@ -20,7 +20,7 @@
 /// 当前 LookinServer 的版本
 static const int LOOKIN_SERVER_VERSION = 7;
 
-static NSString * const LOOKIN_SERVER_READABLE_VERSION = @"1.0.6";
+static NSString * const LOOKIN_SERVER_READABLE_VERSION = @"1.0.7";
 
 /// 当前 LookinClient 的版本
 static const int LOOKIN_CLIENT_VERSION = 7;


### PR DESCRIPTION
It seems that 1.0.7 fix some compilation issue on case-sensitive macOS.

So just hope that this fix could be available via cocoapods.