### PR TITLE
Support for displaying property names of views under Swift projects.

### DIFF
--- a/Src/Server/Others/LKS_TraceManager+Extension.swift
+++ b/Src/Server/Others/LKS_TraceManager+Extension.swift
@@ -1,0 +1,55 @@
+//
+//  LKS_TraceManager+Extension.swift
+//  LookinServer
+//
+//  Created by Shida Zhu on 2022/8/21.
+//
+
+import Foundation
+
+public extension LKS_TraceManager {
+    
+    @objc
+    func _markIVars(ofObject hostObject: AnyObject) {
+        var mirror: Mirror? = Mirror(reflecting: hostObject)
+        var inClass: AnyClass? = type(of: hostObject)
+        while let m = mirror, let childClass = inClass {
+            m.children.forEach { child in
+                if let child = child as? (label: String?, value: NSObject) {
+                    let label: String? = child.label?.replacingOccurrences(of: "$__lazy_storage_$_", with: "")
+                    let value = child.value
+                    
+                    guard (value is UIView) || (value is CALayer) || (value is UIViewController) || (value is UIGestureRecognizer) else {
+                        return
+                    }
+                    
+                    guard let label = label, label.count > 0 else {
+                        return
+                    }
+                    
+                    let ivarTrace = LookinIvarTrace()
+                    ivarTrace.hostObject = hostObject
+                    ivarTrace.hostClassName = NSStringFromClass(childClass)
+                    ivarTrace.ivarName = label
+                    
+                    if (value === hostObject) {
+                        ivarTrace.relation = LookinIvarTraceRelationValue_Self
+                    } else if let hostView = hostObject as? UIView {
+                        var ivarLayer: CALayer? = nil
+                        if let layer = value as? CALayer {
+                            ivarLayer = layer
+                        } else if let view = value as? UIView {
+                            ivarLayer = view.layer
+                        }
+                        if let layer = ivarLayer, layer.superlayer === hostView.layer {
+                            ivarTrace.relation = "superview"
+                        }
+                    }
+                    value.lks_ivarTraces = (value.lks_ivarTraces ?? []) + [ivarTrace]
+                }
+            }
+            mirror = m.superclassMirror
+            inClass = childClass.superclass()
+        }
+    }
+}

--- a/Src/Server/Others/LKS_TraceManager.m
+++ b/Src/Server/Others/LKS_TraceManager.m
@@ -11,6 +11,7 @@
 #import "LookinIvarTrace.h"
 #import "LookinServerDefines.h"
 #import "LKS_LocalInspectManager.h"
+#import "LookinServer/LookinServer-Swift.h"
 
 @implementation LKS_TraceManager
 
@@ -130,6 +131,7 @@
 
 - (void)_markIVarsInAllClassLevelsOfObject:(NSObject *)object {
     [self _markIVarsOfObject:object class:object.class];
+    [self _markIVarsOfObject:object];
 }
 
 - (void)_markIVarsOfObject:(NSObject *)hostObject class:(Class)targetClass {


### PR DESCRIPTION
Now Lookin only supports displaying the property names of views in Objective-C projects. But more and more projects use Swift. However, it does not support displaying property names of views in Swift projects. I hope to add this ability by this pull request.

现在 Lookin 仅仅支持在 Objective-C 的项目下展示视图的属性名. 但是越来越多的项目是才用 swift 的了. 然而却不支持在 Swift 项目下展示视图的属性名. 这个 Pull Request 希望给 Lookin 增加这方面的能力.