### PR TITLE
Fix the bug where UIView fails to render in certain edge cases.

### DIFF
--- a/Src/Main/Server/Others/LKS_HierarchyDisplayItemsMaker.m
+++ b/Src/Main/Server/Others/LKS_HierarchyDisplayItemsMaker.m
@@ -48,7 +48,12 @@
     }
     
     LookinDisplayItem *item = [LookinDisplayItem new];
-    if ([self validateFrame:layer.frame]) {
+    CGRect layerFrame = layer.frame;
+    UIView *hostView = layer.lks_hostView;
+    if (hostView && hostView.superview) {
+        layerFrame = [hostView.superview convertRect:layerFrame toView:nil];
+    }
+    if ([self validateFrame:layerFrame]) {
         item.frame = layer.frame;
     } else {
         NSLog(@"LookinServer - 该 layer 的 frame(%@) 不太寻常，可能导致 Lookin 客户端中图像渲染错误，因此这里暂时将其视为 CGRectZero", NSStringFromCGRect(layer.frame));


### PR DESCRIPTION
In some cases, such as when a UIScrollView contains a view with a huge origin, this view will not be rendered. The reason is that the validity check for the frame of the layer is not relative to the screen coordinates. This sometimes results in a view being visible when its parent node is collapsed, but not visible once the parent node is expanded.

在某些情况下, 比如UIScrollView 内包含一个 orgin 巨大的 view, 这个view 将不会被渲染. 原因是对 layer 的 frame 的合法性检查并不是相对屏幕的坐标. 这就导致有时候一个 view 在父节点折叠的时候可以被看到, 一旦展开其父节点, 就无法看到了.

eg:
UIScrollView: contentSize {375, 1000000} contentOffset {0, 500000}
UIView: frame {{0, 500100}, {100, 50}}