### PR TITLE
Support Search by Memory Address.

### DIFF
--- a/Src/Main/Shared/LookinDisplayItem.m
+++ b/Src/Main/Shared/LookinDisplayItem.m
@@ -500,10 +500,17 @@
         NSAssert(NO, @"");
         return NO;
     }
-    if ([self.title.lowercaseString containsString:string.lowercaseString]) {
+    NSString *searchString = string.lowercaseString;
+    if ([self.title.lowercaseString containsString:searchString]) {
         return YES;
     }
-    if ([self.subtitle.lowercaseString containsString:string.lowercaseString]) {
+    if ([self.subtitle.lowercaseString containsString:searchString]) {
+        return YES;
+    }
+    if ([self.viewObject.memoryAddress containsString:searchString]) {
+        return YES;
+    }
+    if ([self.layerObject.memoryAddress containsString:searchString]) {
         return YES;
     }
     return NO;


### PR DESCRIPTION
Sometimes when troubleshooting issues, such as memory leaks, it is necessary to check whether a specific UIView instance is in the view hierarchy, and this requires searching based on the instance's memory address. However, this is currently not supported. It is hoped that this capability can be added.

有时候在排查问题的时候, 比如在内存泄露时, 需要排查某个特定的UIView实例是否在视图树上, 就需要根据实例的内存地址搜索. 但现在是不支持的. 希望可以支持上这个能力.