### PR TITLE
fix 从bundle获取appIcon时crash

### DIFF
--- a/Src/Main/Shared/LookinAppInfo.m
+++ b/Src/Main/Shared/LookinAppInfo.m
@@ -190,7 +190,16 @@ static NSString * const CodingKey_DeviceType = @"8";
 #if TARGET_OS_TV
     return nil;
 #else
-    NSString *imageName = [[[[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIcons"] objectForKey:@"CFBundlePrimaryIcon"] objectForKey:@"CFBundleIconFiles"] lastObject];
+    NSString *imageName;
+    id CFBundleIcons = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIcons"];
+    if ([CFBundleIcons respondsToSelector:@selector(objectForKey:)]) {
+        id CFBundlePrimaryIcon = [CFBundleIcons objectForKey:@"CFBundlePrimaryIcon"];
+        if ([CFBundlePrimaryIcon respondsToSelector:@selector(objectForKey:)]) {
+            imageName = [[CFBundlePrimaryIcon objectForKey:@"CFBundleIconFiles"] lastObject];
+        } else if ([CFBundlePrimaryIcon isKindOfClass:NSString.class]) {
+            imageName = CFBundlePrimaryIcon;
+        }
+    }
     if (!imageName.length) {
         // 正常情况下拿到的 name 可能比如 “AppIcon60x60”。但某些情况可能为 nil，此时直接 return 否则 [UIImage imageNamed:nil] 可能导致 console 报 "CUICatalog: Invalid asset name supplied: '(null)'" 的错误信息
         return nil;


### PR DESCRIPTION
获取app bundle icon时，CFBundlePrimaryIcon字段可能为词典，也可能为字符串。当其为字符串时，调用objectForKey:导致crash